### PR TITLE
Modified UpdateGauge method to fix issue 7

### DIFF
--- a/metrics/metrics_collector.go
+++ b/metrics/metrics_collector.go
@@ -35,7 +35,7 @@ func (mc *metricCollector) updateCounter() {
 
 func (mc *metricCollector) updateGauge() {
 	for _, c := range mc.gauges {
-		c.Add(rand.Float64())
+		c.Set(rand.Float64())
 	}
 }
 


### PR DESCRIPTION
**Description**
- Modified `UpdateGauge` method by changing `c.add` to `c.set` to allow gauge metric values to go both up and down

**Link to Issue**
Issue 7