### PR TITLE
fix: change goproxy to direct

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.15 AS mod
 WORKDIR $GOPATH/main
 COPY go.mod .
 COPY go.sum .
+ENV GOPROXY direct
 RUN GO111MODULE=on go mod download
 
 FROM golang:1.15 as build


### PR DESCRIPTION
**Description**
add `ENV GOPROXY direct` on Dockerfile to workaround `proxy.golang.org`.

**Link to Issue**
#6 